### PR TITLE
Add sorting option to pages with recipes

### DIFF
--- a/Receptai.client/components/ShimmerLoaders/RecipeContainerShimmer.vue
+++ b/Receptai.client/components/ShimmerLoaders/RecipeContainerShimmer.vue
@@ -3,7 +3,6 @@
 <template>
   <div
     class="lg:basis-1/4 sm:basis-1/3 xsm:basis-1/2 basis-full"
-    data-testid="recipe-container"
   >
     <div class="m-3 animate-pulse">
       <div class="m-auto rounded-md lg:h-56 h-48 bg-concrete-300"></div>

--- a/Receptai.client/components/ShimmerLoaders/RecipeSortAndFilterShimmer.vue
+++ b/Receptai.client/components/ShimmerLoaders/RecipeSortAndFilterShimmer.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="animate-pulse flex flex-col gap-2">
+    <div class="flex flex-row gap-2">
+      <div
+        class="flex flex-1 items-center h-10 bg-concrete-300 rounded-md"
+      ></div>
+      <div
+        class="flex flex-1 items-center h-10 bg-concrete-300 rounded-md"
+      ></div>
+    </div>
+    <div class="h-10 bg-concrete-300 rounded-md"></div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/Receptai.client/components/admin/MyRecipes/RecipeContainer.vue
+++ b/Receptai.client/components/admin/MyRecipes/RecipeContainer.vue
@@ -103,42 +103,6 @@ const deleteRecipe = async () => {
     console.error(e);
   }
 };
-
-interface sortOptions {
-  currSort: string | null;
-  sort: "DEFAULT" | "ASC" | "DESC";
-}
-
-let sort: sortOptions = {
-  currSort: null,
-  sort: "DEFAULT",
-};
-
-const sortCurrValue = ref<null | string>(null);
-const sortByValue = ref<"DEFAULT" | "ASC" | "DESC">("DEFAULT");
-
-const getSortDirection = (value: string): void => {
-  console.log(sortByValue.value);
-  if (sortCurrValue.value === value) {
-    switch (sortByValue.value) {
-      case "DESC":
-        sortByValue.value = "ASC";
-        break;
-      case "ASC":
-        sortByValue.value = "DESC";
-        break;
-      case "DEFAULT":
-        sortByValue.value = "DESC";
-        break;
-    }
-  } else {
-    sortCurrValue.value = value;
-    sortByValue.value = "DESC";
-  }
-
-  sort.currSort = sortCurrValue.value;
-  sort.sort = sortByValue.value;
-};
 </script>
 
 <template>

--- a/Receptai.client/components/admin/components/RecipeSortAndFilter.vue
+++ b/Receptai.client/components/admin/components/RecipeSortAndFilter.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+const model = defineModel();
+
+defineProps<{
+    pageNumber: number,
+    elementsPerPage: number,
+    currentElementCount: number,
+    totalElements: number
+}>();
+</script>
+
+<template>
+<div class="border-2 border-black bg-concrete-100">
+        <div class="flex flex-row border-b-2 border-black">
+          <div class="flex flex-1 gap-2 items-center p-2">
+            <Icon name="solar:filter-bold" color="black" size="26px" />
+            Filter
+          </div>
+          <div
+            class="flex flex-1 gap-2 items-center p-2 border-l-2 border-black"
+          >
+            <Icon name="solar:sort-vertical-linear" color="black" size="26px" />
+            <div class="w-full">
+              <select
+                v-model="model"
+                class="outline-none bg-concrete-100 w-full"
+              >
+                <option class="h-5" value="nameDesc">Name from A to Z</option>
+                <option value="nameAsc">Name from Z to A</option>
+                <option value="DateDesc">Newest first</option>
+                <option value="DateAsc">Oldest first</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="p-2">
+          Showing:
+          <b
+            >{{ pageNumber * elementsPerPage }} -
+            {{ pageNumber * elementsPerPage + currentElementCount }}</b
+          >
+          out of <b>{{ totalElements }}</b> recipes
+        </div>
+      </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/Receptai.client/components/admin/components/RecipeSortAndFilter.vue
+++ b/Receptai.client/components/admin/components/RecipeSortAndFilter.vue
@@ -49,7 +49,7 @@ const selectionOptions = [
     <div class="p-2">
       Showing:
       <b
-        >{{ pageNumber * elementsPerPage }} -
+        >{{ pageNumber * elementsPerPage + 1 }} -
         {{ pageNumber * elementsPerPage + currentElementCount }}</b
       >
       out of <b>{{ totalElements }}</b> recipes

--- a/Receptai.client/components/admin/components/RecipeSortAndFilter.vue
+++ b/Receptai.client/components/admin/components/RecipeSortAndFilter.vue
@@ -2,48 +2,59 @@
 const model = defineModel();
 
 defineProps<{
-    pageNumber: number,
-    elementsPerPage: number,
-    currentElementCount: number,
-    totalElements: number
+  pageNumber: number;
+  elementsPerPage: number;
+  currentElementCount: number;
+  totalElements: number;
 }>();
+
+const selectionOptions = [
+  {
+    value: "nameDesc",
+    name: "Name from A to Z",
+  },
+  {
+    value: "nameAsc",
+    name: "Name from Z to A",
+  },
+  {
+    value: "DateDesc",
+    name: "Newest first",
+  },
+  {
+    value: "DateAsc",
+    name: "Oldest first",
+  },
+];
 </script>
 
 <template>
-<div class="border-2 border-black bg-concrete-100">
-        <div class="flex flex-row border-b-2 border-black">
-          <div class="flex flex-1 gap-2 items-center p-2">
-            <Icon name="solar:filter-bold" color="black" size="26px" />
-            Filter
-          </div>
-          <div
-            class="flex flex-1 gap-2 items-center p-2 border-l-2 border-black"
-          >
-            <Icon name="solar:sort-vertical-linear" color="black" size="26px" />
-            <div class="w-full">
-              <select
-                v-model="model"
-                class="outline-none bg-concrete-100 w-full"
-              >
-                <option class="h-5" value="nameDesc">Name from A to Z</option>
-                <option value="nameAsc">Name from Z to A</option>
-                <option value="DateDesc">Newest first</option>
-                <option value="DateAsc">Oldest first</option>
-              </select>
-            </div>
-          </div>
-        </div>
-        <div class="p-2">
-          Showing:
-          <b
-            >{{ pageNumber * elementsPerPage }} -
-            {{ pageNumber * elementsPerPage + currentElementCount }}</b
-          >
-          out of <b>{{ totalElements }}</b> recipes
+  <div class="border-2 border-black bg-concrete-100">
+    <div class="flex flex-row border-b-2 border-black">
+      <div class="flex flex-1 gap-2 items-center p-2">
+        <Icon name="solar:filter-bold" color="black" size="26px" />
+        Filter
+      </div>
+      <div class="flex flex-1 gap-2 items-center p-2 border-l-2 border-black">
+        <Icon name="solar:sort-vertical-linear" color="black" size="26px" />
+        <div class="w-full">
+          <select v-model="model" class="outline-none bg-concrete-100 w-full">
+            <option v-for="option in selectionOptions" :value="option.value">
+              {{ option.name }}
+            </option>
+          </select>
         </div>
       </div>
+    </div>
+    <div class="p-2">
+      Showing:
+      <b
+        >{{ pageNumber * elementsPerPage }} -
+        {{ pageNumber * elementsPerPage + currentElementCount }}</b
+      >
+      out of <b>{{ totalElements }}</b> recipes
+    </div>
+  </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/Receptai.client/pages/recipes/index.vue
+++ b/Receptai.client/pages/recipes/index.vue
@@ -4,6 +4,7 @@ import RecipeContainer from "@/components/RecipeContainerComponent/RecipeContain
 import Pagination from "@/components/Pagination/Pagination.vue";
 import EmptyListInformation from "@/components/EmptyListInformation.vue";
 import RecipeContainerShimmer from "@/components/ShimmerLoaders/RecipeContainerShimmer.vue";
+import RecipeSortAndFilter from "@/components/admin/components/RecipeSortAndFilter.vue";
 
 interface Recipe {
   id: number;
@@ -131,38 +132,7 @@ getRecipes();
       @button-click="navigateTo('/')"
     />
     <div v-else>
-      <div class="border-2 border-black bg-concrete-100">
-        <div class="flex flex-row border-b-2 border-black">
-          <div class="flex flex-1 gap-2 items-center p-2">
-            <Icon name="solar:filter-bold" color="black" size="26px" />
-            Filter
-          </div>
-          <div
-            class="flex flex-1 gap-2 items-center p-2 border-l-2 border-black"
-          >
-            <Icon name="solar:sort-vertical-linear" color="black" size="26px" />
-            <div class="w-full">
-              <select
-                v-model="selectionValue"
-                class="outline-none bg-concrete-100 w-full"
-              >
-                <option class="h-5" value="nameDesc">Name from A to Z</option>
-                <option value="nameAsc">Name from Z to A</option>
-                <option value="DateDesc">Newest first</option>
-                <option value="DateAsc">Oldest first</option>
-              </select>
-            </div>
-          </div>
-        </div>
-        <div class="p-2">
-          Showing:
-          <b
-            >{{ pageNumber * elementsPerPage }} -
-            {{ pageNumber * elementsPerPage + currentElementCount }}</b
-          >
-          out of <b>{{ totalElements }}</b> recipes
-        </div>
-      </div>
+      <RecipeSortAndFilter :pageNumber :elementsPerPage :currentElementCount :totalElements v-model="selectionValue"  />
       <div class="flex flex-wrap">
         <RecipeContainer
           v-for="item in recipeList"

--- a/Receptai.client/pages/recipes/index.vue
+++ b/Receptai.client/pages/recipes/index.vue
@@ -5,6 +5,7 @@ import Pagination from "@/components/Pagination/Pagination.vue";
 import EmptyListInformation from "@/components/EmptyListInformation.vue";
 import RecipeContainerShimmer from "@/components/ShimmerLoaders/RecipeContainerShimmer.vue";
 import RecipeSortAndFilter from "@/components/admin/components/RecipeSortAndFilter.vue";
+import RecipeSortAndFilterShimmer from "@/components/ShimmerLoaders/RecipeSortAndFilterShimmer.vue";
 
 interface Recipe {
   id: number;
@@ -118,8 +119,11 @@ getRecipes();
     <div>
       <h1 class="text-3xl font-bold text-center m-3">Recipes</h1>
     </div>
-    <div v-if="loading" class="flex flex-wrap">
-      <RecipeContainerShimmer v-for="i in shimmerComponentsCount" />
+    <div v-if="loading">
+      <RecipeSortAndFilterShimmer />
+      <div class="flex flex-wrap">
+        <RecipeContainerShimmer v-for="i in shimmerComponentsCount" />
+      </div>
     </div>
     <EmptyListInformation
       v-else-if="recipeList && recipeList.length === 0"
@@ -132,7 +136,13 @@ getRecipes();
       @button-click="navigateTo('/')"
     />
     <div v-else>
-      <RecipeSortAndFilter :pageNumber :elementsPerPage :currentElementCount :totalElements v-model="selectionValue"  />
+      <RecipeSortAndFilter
+        :pageNumber
+        :elementsPerPage
+        :currentElementCount
+        :totalElements
+        v-model="selectionValue"
+      />
       <div class="flex flex-wrap">
         <RecipeContainer
           v-for="item in recipeList"

--- a/Receptai.client/pages/recipes/index.vue
+++ b/Receptai.client/pages/recipes/index.vue
@@ -52,6 +52,36 @@ const recipeList = ref<Recipe[] | null>(null);
 const loading = ref(true);
 
 const pageNumber = ref(0);
+const totalElements = ref(0);
+const elementsPerPage = ref(0);
+const currentElementCount = ref(0);
+const selectionValue = ref("DateDesc");
+
+watch(selectionValue, () => {
+  switch (selectionValue.value) {
+    case "nameDesc":
+      sortBy.value = "dateCreated";
+      sortAsc.value = false;
+      getRecipes();
+      break;
+    case "nameAsc":
+      sortBy.value = "dateCreated";
+      sortAsc.value = true;
+      getRecipes();
+      break;
+    case "DateDesc":
+      sortBy.value = "name";
+      sortAsc.value = false;
+      getRecipes();
+      break;
+    case "DateAsc":
+      sortBy.value = "name";
+      sortAsc.value = true;
+      getRecipes();
+      break;
+  }
+});
+
 const sortBy = ref("dateCreated");
 const sortAsc = ref(false);
 
@@ -67,6 +97,9 @@ const getRecipes = async () => {
       .then((res) => {
         recipeList.value = res.data.elements;
         totalPages.value = res.data.totalPageCount;
+        totalElements.value = res.data.totalElementCount;
+        elementsPerPage.value = res.data.elementsPerPage;
+        currentElementCount.value = res.data.currentElementCount;
         loading.value = false;
       });
   } catch (e) {
@@ -98,6 +131,38 @@ getRecipes();
       @button-click="navigateTo('/')"
     />
     <div v-else>
+      <div class="border-2 border-black bg-concrete-100">
+        <div class="flex flex-row border-b-2 border-black">
+          <div class="flex flex-1 gap-2 items-center p-2">
+            <Icon name="solar:filter-bold" color="black" size="26px" />
+            Filter
+          </div>
+          <div
+            class="flex flex-1 gap-2 items-center p-2 border-l-2 border-black"
+          >
+            <Icon name="solar:sort-vertical-linear" color="black" size="26px" />
+            <div class="w-full">
+              <select
+                v-model="selectionValue"
+                class="outline-none bg-concrete-100 w-full"
+              >
+                <option class="h-5" value="nameDesc">Name from A to Z</option>
+                <option value="nameAsc">Name from Z to A</option>
+                <option value="DateDesc">Newest first</option>
+                <option value="DateAsc">Oldest first</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="p-2">
+          Showing:
+          <b
+            >{{ pageNumber * elementsPerPage }} -
+            {{ pageNumber * elementsPerPage + currentElementCount }}</b
+          >
+          out of <b>{{ totalElements }}</b> recipes
+        </div>
+      </div>
       <div class="flex flex-wrap">
         <RecipeContainer
           v-for="item in recipeList"

--- a/Receptai.client/pages/recipes/index.vue
+++ b/Receptai.client/pages/recipes/index.vue
@@ -6,6 +6,7 @@ import EmptyListInformation from "@/components/EmptyListInformation.vue";
 import RecipeContainerShimmer from "@/components/ShimmerLoaders/RecipeContainerShimmer.vue";
 import RecipeSortAndFilter from "@/components/admin/components/RecipeSortAndFilter.vue";
 import RecipeSortAndFilterShimmer from "@/components/ShimmerLoaders/RecipeSortAndFilterShimmer.vue";
+import sortOptionSelector from "@/typescript/sortOptionSelector.ts";
 
 interface Recipe {
   id: number;
@@ -60,27 +61,11 @@ const currentElementCount = ref(0);
 const selectionValue = ref("DateDesc");
 
 watch(selectionValue, () => {
-  switch (selectionValue.value) {
-    case "nameDesc":
-      sortBy.value = "dateCreated";
-      sortAsc.value = false;
-      getRecipes();
-      break;
-    case "nameAsc":
-      sortBy.value = "dateCreated";
-      sortAsc.value = true;
-      getRecipes();
-      break;
-    case "DateDesc":
-      sortBy.value = "name";
-      sortAsc.value = false;
-      getRecipes();
-      break;
-    case "DateAsc":
-      sortBy.value = "name";
-      sortAsc.value = true;
-      getRecipes();
-      break;
+  const resultsArray = sortOptionSelector(selectionValue.value);
+  if (resultsArray) {
+    sortBy.value = resultsArray[0] as string;
+    sortAsc.value = resultsArray[1] as boolean;
+    getRecipes();
   }
 });
 

--- a/Receptai.client/pages/search/index.vue
+++ b/Receptai.client/pages/search/index.vue
@@ -6,6 +6,7 @@ import EmptyListInformation from "@/components/EmptyListInformation.vue";
 import RecipeContainerShimmer from "@/components/ShimmerLoaders/RecipeContainerShimmer.vue";
 import SearchForm from "@/components/SearchForm/SearchForm.vue";
 import RecipeSortAndFilter from "@/components/admin/components/RecipeSortAndFilter.vue";
+import RecipeSortAndFilterShimmer from "@/components/ShimmerLoaders/RecipeSortAndFilterShimmer.vue";
 
 interface Recipe {
   id: number;
@@ -142,8 +143,11 @@ if (search.value === undefined || search.value === "") {
     <div>
       <h1 class="text-3xl font-bold text-center m-2">Recipes search page</h1>
     </div>
-    <div v-if="loading" class="flex flex-wrap">
-      <RecipeContainerShimmer v-for="i in shimmerComponentsCount" />
+    <div v-if="loading">
+      <RecipeSortAndFilterShimmer />
+      <div class="flex flex-wrap">
+        <RecipeContainerShimmer v-for="i in shimmerComponentsCount" />
+      </div>
     </div>
     <div v-else-if="search === '' || !search">
       <h3 class="text-lg font-normal text-center m-1">

--- a/Receptai.client/pages/search/index.vue
+++ b/Receptai.client/pages/search/index.vue
@@ -7,6 +7,7 @@ import RecipeContainerShimmer from "@/components/ShimmerLoaders/RecipeContainerS
 import SearchForm from "@/components/SearchForm/SearchForm.vue";
 import RecipeSortAndFilter from "@/components/admin/components/RecipeSortAndFilter.vue";
 import RecipeSortAndFilterShimmer from "@/components/ShimmerLoaders/RecipeSortAndFilterShimmer.vue";
+import sortOptionSelector from "@/typescript/sortOptionSelector.ts";
 
 interface Recipe {
   id: number;
@@ -63,27 +64,11 @@ const currentElementCount = ref(0);
 const selectionValue = ref("DateDesc");
 
 watch(selectionValue, () => {
-  switch (selectionValue.value) {
-    case "nameDesc":
-      sortBy.value = "dateCreated";
-      sortAsc.value = false;
-      getRecipes();
-      break;
-    case "nameAsc":
-      sortBy.value = "dateCreated";
-      sortAsc.value = true;
-      getRecipes();
-      break;
-    case "DateDesc":
-      sortBy.value = "name";
-      sortAsc.value = false;
-      getRecipes();
-      break;
-    case "DateAsc":
-      sortBy.value = "name";
-      sortAsc.value = true;
-      getRecipes();
-      break;
+  const resultsArray = sortOptionSelector(selectionValue.value);
+  if (resultsArray) {
+    sortBy.value = resultsArray[0] as string;
+    sortAsc.value = resultsArray[1] as boolean;
+    getRecipes();
   }
 });
 
@@ -91,7 +76,6 @@ const sortBy = ref("dateCreated");
 const sortAsc = ref(false);
 
 const totalPages = ref(0);
-const totalElementCount = ref(0);
 const siblings = 2;
 
 const search = ref<string | undefined>(undefined);

--- a/Receptai.client/pages/search/index.vue
+++ b/Receptai.client/pages/search/index.vue
@@ -5,6 +5,7 @@ import Pagination from "@/components/Pagination/Pagination.vue";
 import EmptyListInformation from "@/components/EmptyListInformation.vue";
 import RecipeContainerShimmer from "@/components/ShimmerLoaders/RecipeContainerShimmer.vue";
 import SearchForm from "@/components/SearchForm/SearchForm.vue";
+import RecipeSortAndFilter from "@/components/admin/components/RecipeSortAndFilter.vue";
 
 interface Recipe {
   id: number;
@@ -55,6 +56,36 @@ const recipeList = ref<Recipe[] | null>(null);
 const loading = ref(true);
 
 const pageNumber = ref(0);
+const totalElements = ref(0);
+const elementsPerPage = ref(0);
+const currentElementCount = ref(0);
+const selectionValue = ref("DateDesc");
+
+watch(selectionValue, () => {
+  switch (selectionValue.value) {
+    case "nameDesc":
+      sortBy.value = "dateCreated";
+      sortAsc.value = false;
+      getRecipes();
+      break;
+    case "nameAsc":
+      sortBy.value = "dateCreated";
+      sortAsc.value = true;
+      getRecipes();
+      break;
+    case "DateDesc":
+      sortBy.value = "name";
+      sortAsc.value = false;
+      getRecipes();
+      break;
+    case "DateAsc":
+      sortBy.value = "name";
+      sortAsc.value = true;
+      getRecipes();
+      break;
+  }
+});
+
 const sortBy = ref("dateCreated");
 const sortAsc = ref(false);
 
@@ -68,13 +99,18 @@ search.value = route.query.s?.toString().trim();
 
 const getRecipes = async () => {
   try {
-    const res = await axios.get(
-      `${config.public.baseURL}/api/v1/recipe/find/${search.value}?page=${pageNumber.value}&sortBy=${sortBy.value}&sortAsc=${sortAsc.value}`
-    );
-    recipeList.value = res.data.elements;
-    totalPages.value = res.data.totalPageCount;
-    totalElementCount.value = res.data.totalElementCount;
-    loading.value = false;
+    await axios
+      .get(
+        `${config.public.baseURL}/api/v1/recipe/find/${search.value}?page=${pageNumber.value}&sortBy=${sortBy.value}&sortAsc=${sortAsc.value}`
+      )
+      .then((res) => {
+        recipeList.value = res.data.elements;
+        totalPages.value = res.data.totalPageCount;
+        totalElements.value = res.data.totalElementCount;
+        elementsPerPage.value = res.data.elementsPerPage;
+        currentElementCount.value = res.data.currentElementCount;
+        loading.value = false;
+      });
   } catch (e) {
     console.warn("Error fetching recipes", e);
   }
@@ -104,7 +140,7 @@ if (search.value === undefined || search.value === "") {
 <template>
   <div>
     <div>
-      <h1 class="text-3xl font-bold text-center m-3">Recipes search page</h1>
+      <h1 class="text-3xl font-bold text-center m-2">Recipes search page</h1>
     </div>
     <div v-if="loading" class="flex flex-wrap">
       <RecipeContainerShimmer v-for="i in shimmerComponentsCount" />
@@ -126,10 +162,14 @@ if (search.value === undefined || search.value === "") {
         <h3 class="text-lg font-normal text-center">
           Searching by: <b>„{{ search }}“</b>
         </h3>
-        <h3 class="text-sm font-normal text-center">
-          Found <b>{{ totalElementCount }}</b> recipes
-        </h3>
       </div>
+      <RecipeSortAndFilter
+        :pageNumber
+        :elementsPerPage
+        :currentElementCount
+        :totalElements
+        v-model="selectionValue"
+      />
       <div class="flex flex-wrap">
         <RecipeContainer
           v-for="item in recipeList"

--- a/Receptai.client/pages/user/dashboard/My-recipes/index.vue
+++ b/Receptai.client/pages/user/dashboard/My-recipes/index.vue
@@ -52,7 +52,7 @@ interface Category {
   link: string;
 }
 
-interface column {
+interface Column {
   key: string;
   label: string;
   sortable: boolean;
@@ -84,7 +84,7 @@ const loading = ref(true);
 const totalPages = ref(0);
 const siblings = 2;
 
-const sortableColumns: column[] = [
+const sortableColumns: Column[] = [
   {
     key: "id",
     label: "ID",
@@ -138,7 +138,7 @@ const getData = async () => {
   window.scrollTo(0, 0);
 };
 
-const updateDataSort = (item: column) => {
+const updateDataSort = (item: Column) => {
   if (
     previouslySortedColumn.value &&
     previouslySortedColumn.value !== item.key

--- a/Receptai.client/typescript/sortOptionSelector.ts
+++ b/Receptai.client/typescript/sortOptionSelector.ts
@@ -1,0 +1,16 @@
+type GetRecipes = () => void;
+
+const sortOptionSelector = (selectionValue: string) => {
+  switch (selectionValue) {
+    case "nameDesc":
+      return ["dateCreated", false];
+    case "nameAsc":
+      return ["dateCreated", true];
+    case "DateDesc":
+      return ["name", false];
+    case "DateAsc":
+      return ["name", true];
+  }
+};
+
+export default sortOptionSelector;


### PR DESCRIPTION
- Created custom component which adds ability to select a predefined sorting option, shows element count, how many of them you are viewing and also has a place for future filtering button;
- Added that created component to /recipe and /search pages (could be added to /category/{name} page, but sorting is not yeat implemented for that API);
- Created shimmer loader for recipe sorting/filtering component which has been added to corresponding pages;
- Fixed some issues described in prev pull re, #18.