### PR TITLE
Enable setting/changing user profile picture

### DIFF
--- a/Receptai.client/components/Header/components/ProfileMenu.vue
+++ b/Receptai.client/components/Header/components/ProfileMenu.vue
@@ -5,6 +5,7 @@ interface User {
   id: number;
   name: string;
   email: string;
+  avatarUrl: string | null;
 }
 
 interface Navigation {
@@ -25,7 +26,7 @@ defineProps<{
     <div class="my-1">
       <div class="uppercase font-bold text-sm p-3">Account</div>
       <div class="px-4 flex flex-row items-center gap-3 py-2">
-        <ProfilePicture :user_name="user.name" class="w-10 h-10" />
+        <ProfilePicture :userName="user.name" :userUrl="user.avatarUrl" class="w-10 h-10" />
         <div>
           <div class="font-semibold text-sm">{{ user.name }}</div>
           <div class="text-xs">{{ user.email }}</div>

--- a/Receptai.client/components/Header/components/ProfilePicture.vue
+++ b/Receptai.client/components/Header/components/ProfilePicture.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 defineProps<{
   userName: string;
-  userUrl: string | null;
+  userUrl?: string | null;
 }>();
 </script>
 

--- a/Receptai.client/components/Header/components/ProfilePicture.vue
+++ b/Receptai.client/components/Header/components/ProfilePicture.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
-const props = defineProps<{
+defineProps<{
   userName: string;
   userUrl: string | null;
 }>();
-
-const profilePicture = computed(() => {
-  return props.userUrl ? `bg-[url(${props.userUrl})] bg-cover` : null;
-});
 </script>
 
 <template>
   <div
-    class="bg-indigo-300 rounded-full flex justify-center items-center font-semibold"
-    :class="profilePicture"
+    class="bg-indigo-300 rounded-full flex justify-center items-center font-semibold bg-cover"
+    :style="
+      userUrl
+        ? {
+            'background-image': `linear-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)), url(${userUrl})`,
+          }
+        : null
+    "
     data-testid="profile-picture"
   >
     {{

--- a/Receptai.client/components/Header/components/ProfilePicture.vue
+++ b/Receptai.client/components/Header/components/ProfilePicture.vue
@@ -1,23 +1,29 @@
 <script setup lang="ts">
-defineProps<{
-  user_name: string;
+const props = defineProps<{
+  userName: string;
+  userUrl: string | null;
 }>();
+
+const profilePicture = computed(() => {
+  return props.userUrl ? `bg-[url(${props.userUrl})] bg-cover` : null;
+});
 </script>
 
 <template>
   <div
     class="bg-indigo-300 rounded-full flex justify-center items-center font-semibold"
+    :class="profilePicture"
     data-testid="profile-picture"
   >
     {{
-      /[a-zA-Z].*\s.*[a-zA-Z]/.test(user_name)
-        ? user_name
+      /[a-zA-Z].*\s.*[a-zA-Z]/.test(userName)
+        ? userName
             .trim()
             .split(" ")
             .slice(0, 2)
             .map((word) => word[0].toUpperCase())
             .join("")
-        : user_name.trim().substring(0, 2).toUpperCase()
+        : userName.trim().substring(0, 2).toUpperCase()
     }}
   </div>
 </template>

--- a/Receptai.client/components/Header/components/UserBanner.vue
+++ b/Receptai.client/components/Header/components/UserBanner.vue
@@ -8,6 +8,7 @@ interface User {
   id: number;
   name: string;
   email: string;
+  avatarUrl: string | null;
 }
 
 interface Navigation {
@@ -100,7 +101,8 @@ const vClickOutside = {
       <ProfilePicture
         class="hover:ring-[6px] hover:ring-gray-200 hover:scale-105 transition-all duration-150 cursor-pointer w-8 h-8"
         :class="hover ? 'ring-4 ring-gray-100' : null"
-        :user_name="user.name"
+        :userName="user.name"
+        :userUrl="user.avatarUrl"
       />
     </div>
     <ProfileMenu

--- a/Receptai.client/components/admin/ProfilePage/components/ChangeAvatarUrl.vue
+++ b/Receptai.client/components/admin/ProfilePage/components/ChangeAvatarUrl.vue
@@ -28,7 +28,7 @@ const props = defineProps<{
 
 const validationSchema = toTypedSchema(
   zod.object({
-    avatarUrl: zod.string().url().nullable(),
+    avatarUrl: zod.string().url().nullable().or(zod.literal('')),
   })
 );
 

--- a/Receptai.client/components/admin/ProfilePage/components/ChangeAvatarUrl.vue
+++ b/Receptai.client/components/admin/ProfilePage/components/ChangeAvatarUrl.vue
@@ -28,13 +28,7 @@ const props = defineProps<{
 
 const validationSchema = toTypedSchema(
   zod.object({
-    name: zod
-      .string()
-      .min(3, "Name must be at least three characters long.")
-      .regex(
-        /^[a-zA-Z]{3,}(?: [a-zA-Z]+){0,2}$/,
-        "Name can't contain special symbols."
-      ),
+    avatarUrl: zod.string().url().nullable(),
   })
 );
 
@@ -42,14 +36,17 @@ const { handleSubmit, errors } = useForm({
   validationSchema,
 });
 
-const { value: name } = useField("name");
+const { value: avatarUrl } = useField("avatarUrl");
 
-name.value = props.TastyBytes_user?.user.name;
+avatarUrl.value = props.TastyBytes_user?.user.avatarUrl;
 
 const onSubmit = handleSubmit(async () => {
   showConfirmation.value = false;
 
-  if (!props.TastyBytes_user || name.value === props.TastyBytes_user.user.name) {
+  if (
+    !props.TastyBytes_user ||
+    avatarUrl.value === props.TastyBytes_user.user.name
+  ) {
     return;
   }
 
@@ -58,7 +55,7 @@ const onSubmit = handleSubmit(async () => {
       await axios.patch(
         `${config.public.baseURL}/api/v1/user/edit/${props.TastyBytes_user.user.id}`,
         {
-          newName: name.value,
+            newProfileAvatarUrl: avatarUrl.value,
         },
         {
           headers: { Authorization: `Bearer ${props.TastyBytes_user.token}` },
@@ -66,18 +63,18 @@ const onSubmit = handleSubmit(async () => {
       );
 
       const newObject = props.TastyBytes_user;
-      newObject.user.name = name.value as string;
-      name.value = newObject.user.name;
+      newObject.user.name = avatarUrl.value as string;
+      avatarUrl.value = newObject.user.name;
       addNotification(
-        "Name change was successful! Keep in mind that your change might take some time to show everywhere.",
+        "User avatar url change was successful! Keep in mind that your change might take some time to show everywhere.",
         "Success"
       );
     } catch (e) {
       console.warn(e);
 
-      name.value = props.TastyBytes_user.user.name;
+      avatarUrl.value = props.TastyBytes_user.user.avatarUrl;
       addNotification(
-        "There was an error when changing your name. Please try again.",
+        "There was an error when changing your avatar url. Please try again.",
         "Error"
       );
     }
@@ -87,19 +84,19 @@ const onSubmit = handleSubmit(async () => {
 const onCancel = () => {
   showConfirmation.value = false;
 
-  if (!props.TastyBytes_user){
-    return
+  if (!props.TastyBytes_user) {
+    return;
   }
 
-  name.value = props.TastyBytes_user.user.name;
+  avatarUrl.value = props.TastyBytes_user.user.avatarUrl;
 };
 </script>
 
 <template>
   <form class="flex flex-col relative" @submit.prevent="onSubmit">
     <div class="flex gap-2 items-center flex-row">
-      <label class="font-medium text-gray-950">Name</label>
-      <span class="text-red-600 text-sm">{{ errors.name }}</span>
+      <label class="font-medium text-gray-950">Avatar URL</label>
+      <span class="text-red-600 text-sm">{{ errors.avatarUrl }}</span>
     </div>
 
     <div>
@@ -109,10 +106,9 @@ const onCancel = () => {
         :class="
           showConfirmation ? '!bg-concrete-100 !border-concrete-300' : null
         "
-        name="name"
-        placeholder="Full name"
-        autocomplete="name"
-        v-model="name"
+        name="avatarUrl"
+        placeholder="Avatar url"
+        v-model="avatarUrl"
       />
       <div
         v-if="showConfirmation"

--- a/Receptai.client/components/admin/ProfilePage/components/ChangeAvatarUrl.vue
+++ b/Receptai.client/components/admin/ProfilePage/components/ChangeAvatarUrl.vue
@@ -63,8 +63,8 @@ const onSubmit = handleSubmit(async () => {
       );
 
       const newObject = props.TastyBytes_user;
-      newObject.user.name = avatarUrl.value as string;
-      avatarUrl.value = newObject.user.name;
+      newObject.user.avatarUrl = avatarUrl.value as string;
+      avatarUrl.value = newObject.user.avatarUrl;
       addNotification(
         "User avatar url change was successful! Keep in mind that your change might take some time to show everywhere.",
         "Success"

--- a/Receptai.client/components/admin/ProfilePage/components/ChangeName.vue
+++ b/Receptai.client/components/admin/ProfilePage/components/ChangeName.vue
@@ -3,16 +3,9 @@ import axios from "axios";
 import { Form, useForm, useField } from "vee-validate";
 import { toTypedSchema } from "@vee-validate/zod";
 import * as zod from "zod";
-
-import ProfilePicture from "@/components/Header/components/ProfilePicture.vue";
 import { addNotification } from "~/store/store";
-import PasswordChange from "@/components/admin/ProfilePage/components/PasswordChange.vue";
-import ErrorBaner from "@/components/Error/ErrorBaner.vue";
-import ChangeName from "@/components/admin/ProfilePage/components/ChangeName.vue";
 
-definePageMeta({
-  middleware: "auth",
-});
+import InputWithConfirmation from "../../components/InputWithConfirmation.vue";
 
 const config = useRuntimeConfig();
 
@@ -75,7 +68,7 @@ if (TastyBytes_user.value) {
   TastyBytes_user.value = null;
 }
 
-const onSubmit = handleSubmit(async (data) => {
+const onSubmit = handleSubmit(async () => {
   showConfirmation.value = false;
 
   if (name.value === user.name) {
@@ -120,51 +113,53 @@ const onCancel = () => {
 </script>
 
 <template>
-  <div v-if="user.name !== null">
+  <form class="flex flex-col relative" @submit.prevent="onSubmit">
+    <div class="flex gap-2 items-center flex-row">
+      <label class="font-medium text-gray-950">Name</label>
+      <span class="text-red-600 text-sm">{{ errors.name }}</span>
+    </div>
+
     <div>
-      <h1 class="text-3xl font-bold text-center m-5">Profile</h1>
-    </div>
-    <div v-if="user">
-      <div class="flex flex-col justify-center items-center">
-        <div
-          class="w-full py-10 flex justify-center items-center rounded-md bg-cover bg-[url(/images/food-image.jpg)] shadow-[inset_0_0_0_1000px_#0000004f] bg-center"
+      <input
+        @focus="showConfirmation = true"
+        class="w-full bg-concrete-50 hover:bg-concrete-100 focus:bg-concrete-100 px-2 py-2 focus:border-concrete-300 border-2 border-concrete-50 transition-colors duration-150 rounded-sm text-gray-950 outline-none"
+        :class="
+          showConfirmation ? '!bg-concrete-100 !border-concrete-300' : null
+        "
+        name="name"
+        placeholder="Full name"
+        autocomplete="name"
+        v-model="name"
+      />
+      <div
+        v-if="showConfirmation"
+        class="absolute right-0 -bottom-8 flex gap-2 z-50"
+      >
+        <button
+          type="submit"
+          class="h-7 w-7 bg-gray-200 border border-gray-300 rounded-sm transition-all duration-150 hover:bg-gray-300"
         >
-          <ProfilePicture
-            class="w-20 h-20 border-[3px] border-white text-3xl shadow-[2px_2px_3px_1px_#ffffff82]"
-            :user_name="user.name"
+          <Icon
+            name="material-symbols:done-rounded"
+            size="18px"
+            color="black"
           />
-        </div>
-      </div>
-      <div class="max-w-2xl m-auto flex flex-col gap-2 mt-4">
-        <div class="font-bold text-xl">User details</div>
-        <div
-          class="m-auto border border-concrete-400 rounded-sm p-4 w-full flex flex-col gap-4 shadow-[0_1px_2px_1px_#828282]"
+        </button>
+        <button
+          type="button"
+          value="cancel"
+          @click="onCancel"
+          class="h-7 w-7 bg-gray-200 border border-gray-300 rounded-sm transition-all duration-150 hover:bg-gray-300"
         >
-          <ErrorBaner v-if="error" :errorText />
-          <ChangeName />
-          <div class="flex flex-col">
-            <label class="font-medium text-gray-950">Email</label>
-            <div
-              class="w-full bg-concrete-50 hover:bg-concrete-100 px-2 py-2 transition-colors duration-150 rounded-sm text-gray-950"
-            >
-              {{ user.email }}
-            </div>
-          </div>
-          <div class="flex flex-col">
-            <label class="font-medium text-gray-950">Avatar URL</label>
-            <div
-              class="w-full bg-concrete-50 hover:bg-concrete-100 px-2 py-2 transition-colors duration-150 rounded-sm text-gray-950"
-              :class="user.avatarUrl ? null : '!text-gray-400'"
-            >
-              {{ user.avatarUrl ? user.avatarUrl : "Empty" }}
-            </div>
-          </div>
-        </div>
+          <Icon
+            name="material-symbols:close-rounded"
+            size="18px"
+            color="black"
+          />
+        </button>
       </div>
-      <PasswordChange />
     </div>
-  </div>
-  <div v-else>Loading...</div>
+  </form>
 </template>
 
 <style scoped></style>

--- a/Receptai.client/pages/user/profile.vue
+++ b/Receptai.client/pages/user/profile.vue
@@ -132,7 +132,8 @@ const onCancel = () => {
         >
           <ProfilePicture
             class="w-20 h-20 border-[3px] border-white text-3xl shadow-[2px_2px_3px_1px_#ffffff82]"
-            :user_name="user.name"
+            :userName="user.name"
+            :userUrl="user.avatarUrl"
           />
         </div>
       </div>

--- a/Receptai.client/pages/user/profile.vue
+++ b/Receptai.client/pages/user/profile.vue
@@ -9,6 +9,7 @@ import { addNotification } from "~/store/store";
 import PasswordChange from "@/components/admin/ProfilePage/components/PasswordChange.vue";
 import ErrorBaner from "@/components/Error/ErrorBaner.vue";
 import ChangeName from "@/components/admin/ProfilePage/components/ChangeName.vue";
+import ChangeAvatarUrl from "@/components/admin/ProfilePage/components/ChangeAvatarUrl.vue";
 
 definePageMeta({
   middleware: "auth",
@@ -141,7 +142,7 @@ const onCancel = () => {
           class="m-auto border border-concrete-400 rounded-sm p-4 w-full flex flex-col gap-4 shadow-[0_1px_2px_1px_#828282]"
         >
           <ErrorBaner v-if="error" :errorText />
-          <ChangeName />
+          <ChangeName :TastyBytes_user="TastyBytes_user" />
           <div class="flex flex-col">
             <label class="font-medium text-gray-950">Email</label>
             <div
@@ -150,15 +151,7 @@ const onCancel = () => {
               {{ user.email }}
             </div>
           </div>
-          <div class="flex flex-col">
-            <label class="font-medium text-gray-950">Avatar URL</label>
-            <div
-              class="w-full bg-concrete-50 hover:bg-concrete-100 px-2 py-2 transition-colors duration-150 rounded-sm text-gray-950"
-              :class="user.avatarUrl ? null : '!text-gray-400'"
-            >
-              {{ user.avatarUrl ? user.avatarUrl : "Empty" }}
-            </div>
-          </div>
+          <ChangeAvatarUrl :TastyBytes_user="TastyBytes_user" />
         </div>
       </div>
       <PasswordChange />

--- a/Receptai.client/test/ProfilePictureComponent.test.js
+++ b/Receptai.client/test/ProfilePictureComponent.test.js
@@ -34,7 +34,7 @@ describe.each([
 ])("Profile picture", ({ name, expected }) => {
   test(`should display abbreviation of ${name}`, () => {
     const { getByTestId } = render(ProfilePicture, {
-      props: { user_name: name },
+      props: { userName: name },
     });
 
     expect(getByTestId("profile-picture").textContent).toBe(expected);


### PR DESCRIPTION
- Extracted old name changing logic in to a seperate component;
- Added ability to add/change profile avatarURL in profile managment page;
- When setting profile picture, you can confirm, cancel as previously on name change input;
- When page is reloaded, profile picture now shows up as background of two letters of your name/username;
- If picture is invalid/not set, nothing is displayed.

*form component that is used in both name and avatarURL change probably could be implemented so it could be reused, but it was kind of a hassle to do that with validation, so I chose to implement different components for each.